### PR TITLE
Fix connection pooling: don't send Connection: close header

### DIFF
--- a/s3/s3.go
+++ b/s3/s3.go
@@ -1148,7 +1148,6 @@ func (s3 *S3) setupHttpRequest(req *request) (*http.Request, error) {
 		Method:     req.method,
 		ProtoMajor: 1,
 		ProtoMinor: 1,
-		Close:      true,
 		Header:     req.headers,
 		Form:       req.params,
 	}


### PR DESCRIPTION
HTTP requests sent by the s3 library were sending a header requesting
that the remote side close the connection after each request. This
prevented connection pooling from working. Unsetting this flag greatly
improves performance.