### PR TITLE
Removes stale S3 test for the deleted ReadTimeout parameter

### DIFF
--- a/s3/s3_test.go
+++ b/s3/s3_test.go
@@ -291,31 +291,6 @@ func (s *S) TestPutCopy(c *check.C) {
 	c.Assert(req.Header["X-Amz-Acl"], check.DeepEquals, []string{"private"})
 }
 
-func (s *S) TestPutObjectReadTimeout(c *check.C) {
-	s.s3.ReadTimeout = 50 * time.Millisecond
-	defer func() {
-		s.s3.ReadTimeout = 0
-	}()
-
-	b := s.s3.Bucket("bucket")
-	err := b.Put("name", []byte("content"), "content-type", s3.Private, s3.Options{})
-
-	// Make sure that we get a timeout error.
-	c.Assert(err, check.NotNil)
-
-	// Set the response after the request times out so that the next request will work.
-	testServer.Response(200, nil, "")
-
-	// This time set the response within our timeout period so that we expect the call
-	// to return successfully.
-	go func() {
-		time.Sleep(25 * time.Millisecond)
-		testServer.Response(200, nil, "")
-	}()
-	err = b.Put("name", []byte("content"), "content-type", s3.Private, s3.Options{})
-	c.Assert(err, check.IsNil)
-}
-
 func (s *S) TestPutReader(c *check.C) {
 	testServer.Response(200, nil, "")
 


### PR DESCRIPTION
Signed-off-by: Brian Bland <brian.bland@docker.com>