### PR TITLE
Add ap-northeast-2 region

### DIFF
--- a/aws/aws.go
+++ b/aws/aws.go
@@ -75,7 +75,7 @@ type Region struct {
 
 var Regions = map[string]Region{
 	APNortheast.Name:  APNortheast,
-	APNortheast2.Name:  APNortheast2,
+	APNortheast2.Name: APNortheast2,
 	APSoutheast.Name:  APSoutheast,
 	APSoutheast2.Name: APSoutheast2,
 	EUCentral.Name:    EUCentral,

--- a/aws/aws.go
+++ b/aws/aws.go
@@ -75,6 +75,7 @@ type Region struct {
 
 var Regions = map[string]Region{
 	APNortheast.Name:  APNortheast,
+	APNortheast2.Name:  APNortheast2,
 	APSoutheast.Name:  APSoutheast,
 	APSoutheast2.Name: APSoutheast2,
 	EUCentral.Name:    EUCentral,

--- a/aws/regions.go
+++ b/aws/regions.go
@@ -216,6 +216,30 @@ var APNortheast = Region{
 	"https://elasticache.ap-northeast-1.amazonaws.com",
 }
 
+var APNortheast2 = Region{
+	"ap-northeast-2",
+	ServiceInfo{"https://ec2.ap-northeast-2.amazonaws.com", V2Signature},
+	"https://s3-ap-northeast-2.amazonaws.com",
+	"",
+	true,
+	true,
+	"https://sdb.ap-northeast-2.amazonaws.com",
+	"https://sns.ap-northeast-2.amazonaws.com",
+	"https://sqs.ap-northeast-2.amazonaws.com",
+	"",
+	"https://iam.amazonaws.com",
+	"https://elasticloadbalancing.ap-northeast-2.amazonaws.com",
+	"https://kms.ap-northeast-2.amazonaws.com",
+	"https://dynamodb.ap-northeast-2.amazonaws.com",
+	ServiceInfo{"https://monitoring.ap-northeast-2.amazonaws.com", V2Signature},
+	"https://autoscaling.ap-northeast-2.amazonaws.com",
+	ServiceInfo{"https://rds.ap-northeast-2.amazonaws.com", V2Signature},
+	"https://kinesis.ap-northeast-2.amazonaws.com",
+	"https://sts.amazonaws.com",
+	"https://cloudformation.ap-northeast-2.amazonaws.com",
+	"https://elasticache.ap-northeast-2.amazonaws.com",
+}
+
 var SAEast = Region{
 	"sa-east-1",
 	ServiceInfo{"https://ec2.sa-east-1.amazonaws.com", V2Signature},

--- a/aws/regions.go
+++ b/aws/regions.go
@@ -223,7 +223,7 @@ var APNortheast2 = Region{
 	"",
 	true,
 	true,
-	"https://sdb.ap-northeast-2.amazonaws.com",
+	"",
 	"https://sns.ap-northeast-2.amazonaws.com",
 	"https://sqs.ap-northeast-2.amazonaws.com",
 	"",
@@ -235,7 +235,7 @@ var APNortheast2 = Region{
 	"https://autoscaling.ap-northeast-2.amazonaws.com",
 	ServiceInfo{"https://rds.ap-northeast-2.amazonaws.com", V2Signature},
 	"https://kinesis.ap-northeast-2.amazonaws.com",
-	"https://sts.amazonaws.com",
+	"https://sts.ap-northeast-2.amazonaws.com",
 	"https://cloudformation.ap-northeast-2.amazonaws.com",
 	"https://elasticache.ap-northeast-2.amazonaws.com",
 }


### PR DESCRIPTION
AWS opened ap-northeast-2 (Seoul, South Korea) region in Jan 2016.

Signed-off-by: Taeho Kim <xissysnd@gmail.com>